### PR TITLE
実行時に shell が間に入らないようにする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
 
 RUN gem install slack_twitter_egosa
 
-CMD slack_twitter_egosa
+CMD ["slack_twitter_egosa"]


### PR DESCRIPTION
現在の Dockerfile の記述（`CMD slack_twitter_egosa`）だと、起動時に間に shell が入ってしまいます。

その為、停止時（`docker stop`などの時）に SIGTERM が shell にしか届かず、本来停止したい ruby まで伝わらずに timeout （docker stop のデフォルトで 10sec）後の SIGKILL で強制的に停止されてしまっています。

本来の ruby に SIGTERM が伝わり、即座に正しく終了できる exec 形式で実行するように記述を変更をしています。

参考
[Dockerfile リファレンス — Docker-docs-ja 1.12.RC ドキュメント](http://docs.docker.jp/engine/reference/builder.html#cmd)
